### PR TITLE
added missing includes

### DIFF
--- a/Cell.h
+++ b/Cell.h
@@ -3,6 +3,7 @@
 
 #include <cstring>
 #include <string>
+#include <stdexcept>
 #include "cell_types.h"
 #include <unordered_map>
 

--- a/Circuit.h
+++ b/Circuit.h
@@ -9,6 +9,7 @@
 #include <unordered_set>
 #include <unordered_map>
 #include <vector>
+#include <stdexcept>
 
 #include "Cell.h"
 


### PR DESCRIPTION
There is an include dependency flaw.
Both files use `std::logic_error` without the proper include.
This PR fixes the issue.