### PR TITLE
Add `--synthesis-template` arg to `parse.py`

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -42,6 +42,11 @@ def parse_arguments():
                         help="Name of the top module")
 
     # Optional arguments
+    # Allow the caller to bring their own synthesis template
+    parser.add_argument("-st", "--synthesis-template", dest="synthesis_template_path",
+                        default=TEMPLATE_FILE_PATH,
+                        type=helpers.ap_check_file_exists,
+                        help="Path of the template yosys synthesis script")
     parser.add_argument("-l", "--label", dest="label_file_path",
                         required=False, default=LABEL_FILE_PATH, type=helpers.ap_check_dir_exists,
                         help="Path of output label file (default: %(default)s)")
@@ -78,7 +83,7 @@ def parse_arguments():
 
 def create_yosys_script(args):
     yosys_script = ""
-    with open(TEMPLATE_FILE_PATH) as template_file:
+    with open(args.synthesis_template_path) as template_file:
         yosys_script += template_file.read()
     assert("{READ_FILES}" in yosys_script)
     read_verilog_commands = "\n".join(["read_verilog %s;" % os.path.abspath(f) for f in args.verilog_file_paths]) + "\n"
@@ -109,6 +114,9 @@ def yosys_synth(args):
         if args.synthesis_file_path:
             print("Using custom yosys synthesis script: %s" % args.synthesis_file_path)
             yosys_synth_file_path = args.synthesis_file_path
+        elif args.synthesis_template_path:
+            print("Using custom yosys template synthesis script: %s" % args.synthesis_template_path)
+            yosys_synth_file_path = SYNTH_FILE_PATH
         else:
             yosys_synth_file_path = SYNTH_FILE_PATH
         

--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,7 @@ python3 parse.py
 The arguments for the standard mode of operation are:
   * `--source`: file path(s) to the source file(s). `parse.py` will automatically generate a Yosys synthesis script. Then, the `--synthesis-file` option must not be used.
   * `--synthesis-file`: In case one does not want to use the auto-generated script, this option can be used to specify a custom Yosys synthesis script. Then, the `--source` option must not be used because the script already includes the paths of the sources.
+  * `--synthesis-template`: an optional template yosys synthesis script that is used for patching instead of default `template/yosys_synth_template.txt`. The `--source` option can be used with this argument. The difference between `--synthesis-file` and `--synthesis-template` is that the former is directly passed to yosys, while the latter is patched with the source files passed with `--source`. 
   * `--top-module`: the name of the top module
   
 Optional arguments include:


### PR DESCRIPTION
I like the fact that `parse.py` has `create_yosys_script` function, that takes a yosys template synthesis script and produces the final script by populating `READ_FILES`, `TOP_MODULE` etc. variables conveniently.

In my use case, I needed to make a quite a few modifications in the yosys script so I was using `--synthesis-file` to provide the script. However, since this argument does not pass through `create_yosys_script` function, `parse.py` does not automatically handle source files, module names etc. On the other hand, as far as I understand, there is not an elegant way to access environment inside a yosys script, and therefore one ends up hard coding the source file paths into the yosys script. This was problematic in my use case, because

1. I invoke CocoAlma flow outside its own directory, and
2. My source files are spread around few different directories, and hard coded paths would not work for other folks who would like to run the same flow.

I think it would be great to have a arg to pass template yosys script (instead of the final yosys script). This PR brings this change.

It could also be possible to remove this `--synthesis-template` and instead define a new arg `--path-synthesis-file` that changes how `--synthesis-file` is interpreted.

cc: @vedadux @vogelpi 

