### PR TITLE
Bump networkx version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-networkx==2.4
+networkx>=3.0
 python-sat==0.1.7.dev10
 wheel
 pytest


### PR DESCRIPTION
My python version is Python 3.11.5, and I am getting the following error when I am running the parse script:

```
Traceback (most recent call last):
  File "/usr/local/google/home/fatihballi/Documents/coco-alma/verify.py", line 3, in <module>
    from CircuitGraph import CircuitGraph
  File "/usr/local/google/home/fatihballi/Documents/coco-alma/CircuitGraph.py", line 2, in <module>
    import networkx as nx
  File "/usr/local/google/home/fatihballi/ot_tools/coco-env/lib/python3.11/site-packages/networkx/__init__.py", line 115, in <module>
    import networkx.readwrite
  File "/usr/local/google/home/fatihballi/ot_tools/coco-env/lib/python3.11/site-packages/networkx/readwrite/__init__.py", line 15, in <module>
    from networkx.readwrite.graphml import *
  File "/usr/local/google/home/fatihballi/ot_tools/coco-env/lib/python3.11/site-packages/networkx/readwrite/graphml.py", line 314, in <module>
    class GraphML(object):
  File "/usr/local/google/home/fatihballi/ot_tools/coco-env/lib/python3.11/site-packages/networkx/readwrite/graphml.py", line 346, in GraphML
    (np.int, "int"), (np.int8, "int"),
     ^^^^^^
  File "/usr/local/google/home/fatihballi/ot_tools/coco-env/lib/python3.11/site-packages/numpy/__init__.py", line 324, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'inf'?
```

This is because of a deprecated numpy feature that `networkx==2.4` relys on.

This numpy deprecation first appears in the release 1.20.0 (see https://github.com/numpy/numpy/pull/14882/commits/70f4526b16b1f5815c7a2d46a2b10f1961166463) , and this `networkx` recognizes this version of numpy as a default requirement since 3.0 (see https://github.com/networkx/networkx/commit/bf2041122dd29eb69d4e6f94d2d9a09faee9e4d0). Hence, bumping to 3.0 solves the problem.